### PR TITLE
fix: work-around game creating creeps with id of type number

### DIFF
--- a/src/objects/impls/game_object.rs
+++ b/src/objects/impls/game_object.rs
@@ -20,8 +20,8 @@ extern "C" {
 
     /// The unique ID of this object that you can use in
     /// /game/utils::getObjectById
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &GameObject) -> JsString;
+    #[wasm_bindgen(method, getter, js_name = "id")]
+    pub fn id_internal(this: &GameObject) -> JsValue;
 
     /// The X coordinate in the room.
     #[wasm_bindgen(method, getter)]
@@ -57,6 +57,28 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = getRangeTo)]
     pub fn get_range_to(this: &GameObject, pos: &Object) -> u8;
+}
+
+impl GameObject {
+    /* Although Creep.id is documented as a string, in practice it is sometimes of
+     * type number.
+     * This seems to happen in swamp & spawn but not in ctf.
+     * This function returns a JsString always, converting if necessary.
+     */
+    pub fn id(&self) -> JsString {
+        let i = self.id_internal();
+        let as_str = i.dyn_into::<JsString>();
+        match as_str {
+            Ok(s) => s,
+            Err(i) => {
+                let as_f64 = i.as_f64();
+                match as_f64 {
+                    Some(f) => JsString::from(format!("{f}")),
+                    None => i.unchecked_into::<JsString>(), // this will probably crash
+                }
+            }
+        }
+    }
 }
 
 impl<T> GameObjectProperties for T

--- a/src/objects/impls/game_object.rs
+++ b/src/objects/impls/game_object.rs
@@ -60,8 +60,8 @@ extern "C" {
 }
 
 impl GameObject {
-    /* Although Creep.id is documented as a string, in practice it is sometimes of
-     * type number.
+    /* Although Creep.id is documented as a string, in practice it is sometimes
+     * of type number.
      * This seems to happen in swamp & spawn but not in ctf.
      * This function returns a JsString always, converting if necessary.
      */


### PR DESCRIPTION
seems to happen on spawn & swamp but not on ctf mode. documentation states that creep.id is of type string, so this is a bug in the game.

work-around for #4

I thought about solving this from javascript side (by adding a method to creep prototype which returns calls creep.id.toString() and returning that). However the api doesn't provide any javascript so I did the fix on the rust side - in the case where a creep has a numeric id, this fix creates converts the number to a string on the rust side, then sends that to the js side to create a string so there is a small cost.