### PR TITLE
fix: OwnedStructure now usable with get_objects_by_prototype

### DIFF
--- a/src/constants/prototypes.rs
+++ b/src/constants/prototypes.rs
@@ -35,6 +35,7 @@ typesafe_prototype_constants! {
     pub struct RESOURCE = (RESOURCE_PROTOTYPE, Resource);
     pub struct SOURCE = (SOURCE_PROTOTYPE, Source);
     pub struct STRUCTURE = (STRUCTURE_PROTOTYPE, Structure);
+    pub struct OWNED_STRUCTURE = (OWNED_STRUCTURE_PROTOTYPE, OwnedStructure);
     pub struct STRUCTURE_CONTAINER = (STRUCTURE_CONTAINER_PROTOTYPE, StructureContainer);
     pub struct STRUCTURE_EXTENSION = (STRUCTURE_EXTENSION_PROTOTYPE, StructureExtension);
     pub struct STRUCTURE_RAMPART = (STRUCTURE_RAMPART_PROTOTYPE, StructureRampart);


### PR DESCRIPTION
Prototype hierarchy from the docs is, e.g.

StructureSpawn -> OwnedStructure -> Structure -> GameObject

OwnedStructure was missing from the structs that are set up for get_objects_by_prototype
