### PR TITLE
Visuals, Position

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ arrayvec = "0.5"
 enum_dispatch = "0.3"
 enum-iterator = "0.6"
 js-sys = "0.3"
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -70,7 +70,7 @@ mod types;
 //pub mod look; // TODO: most/all of this is World specific
 //pub mod find; // TODO: most/all of this is World specific
 
-pub use self::{numbers::*, small_enums::*, types::*};
+pub use self::{extra::*, numbers::*, small_enums::*, types::*};
 //pub use self::{extra::*, look::*, recipes::FactoryRecipe}; // TODO: most/all
 // of this is World specific
 

--- a/src/constants/extra.rs
+++ b/src/constants/extra.rs
@@ -75,3 +75,7 @@ pub const RANGED_MASS_ATTACK_POWER_RANGE_2: u32 = 4;
 ///
 /// [`Creep::ranged_mass_attack`]: crate::objects::Creep::ranged_mass_attack
 pub const RANGED_MASS_ATTACK_POWER_RANGE_3: u32 = 1;
+
+pub const ROOM_WIDTH: u8 = 100;
+
+pub const ROOM_HEIGHT: u8 = 100;

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -95,6 +95,23 @@ pub enum Direction {
     TopLeft = 8,
 }
 
+impl From<Direction> for (i8, i8) {
+    /// Returns the change in (x, y) when moving in each direction.
+    #[inline]
+    fn from(direction: Direction) -> (i8, i8) {
+        match direction {
+            Direction::Top => (0, -1),
+            Direction::TopRight => (1, -1),
+            Direction::Right => (1, 0),
+            Direction::BottomRight => (1, 1),
+            Direction::Bottom => (0, 1),
+            Direction::BottomLeft => (-1, 1),
+            Direction::Left => (-1, 0),
+            Direction::TopLeft => (-1, -1),
+        }
+    }
+}
+
 impl ::std::ops::Neg for Direction {
     type Output = Direction;
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 
 pub mod pathfinder;
 pub mod utils;
+pub mod visual;
 
 #[wasm_bindgen(module = "game")]
 extern "C" {

--- a/src/game/pathfinder.rs
+++ b/src/game/pathfinder.rs
@@ -1,3 +1,4 @@
+use crate::constants::Direction;
 use js_sys::{Array, Object};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -17,18 +18,44 @@ impl fmt::Display for Position {
 
 impl Position {
     pub fn range_to(&self, pos: &Position) -> u8 {
-        let diff_x = if self.x > pos.x {
-            self.x - pos.x
-        } else {
-            pos.x - self.x
-        };
-        let diff_y = if self.y > pos.y {
-            self.y - pos.y
-        } else {
-            pos.y - self.y
-        };
+        std::cmp::max(self.x.abs_diff(pos.x), self.y.abs_diff(pos.y))
+    }
 
-        std::cmp::max(diff_x, diff_y)
+    pub fn dir(&self, dir: Direction) -> Position {
+        match dir {
+            Direction::Top => Position {
+                x: self.x,
+                y: self.y - 1,
+            },
+            Direction::TopRight => Position {
+                x: self.x + 1,
+                y: self.y - 1,
+            },
+            Direction::Right => Position {
+                x: self.x + 1,
+                y: self.y,
+            },
+            Direction::BottomRight => Position {
+                x: self.x + 1,
+                y: self.y + 1,
+            },
+            Direction::Bottom => Position {
+                x: self.x,
+                y: self.y + 1,
+            },
+            Direction::BottomLeft => Position {
+                x: self.x - 1,
+                y: self.y + 1,
+            },
+            Direction::Left => Position {
+                x: self.x - 1,
+                y: self.y,
+            },
+            Direction::TopLeft => Position {
+                x: self.x - 1,
+                y: self.y - 1,
+            },
+        }
     }
 }
 

--- a/src/game/pathfinder.rs
+++ b/src/game/pathfinder.rs
@@ -1,11 +1,41 @@
 use js_sys::{Array, Object};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use wasm_bindgen::prelude::*;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Position {
     pub x: u8,
     pub y: u8,
+}
+
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[pos {},{}]", self.x, self.y)
+    }
+}
+
+impl Position {
+    pub fn range_to(&self, pos: &Position) -> u8 {
+        let diff_x = if self.x > pos.x {
+            self.x - pos.x
+        } else {
+            pos.x - self.x
+        };
+        let diff_y = if self.y > pos.y {
+            self.y - pos.y
+        } else {
+            pos.y - self.y
+        };
+
+        std::cmp::max(diff_x, diff_y)
+    }
+}
+
+impl From<Position> for JsValue {
+    fn from(pos: Position) -> JsValue {
+        serde_wasm_bindgen::to_value(&pos).expect("serializable Position")
+    }
 }
 
 #[wasm_bindgen(module = "game/path-finder")]

--- a/src/game/pathfinder.rs
+++ b/src/game/pathfinder.rs
@@ -1,9 +1,7 @@
-use crate::constants::Direction;
-use crate::constants::{ROOM_HEIGHT, ROOM_WIDTH};
+use crate::constants::{Direction, ROOM_HEIGHT, ROOM_WIDTH};
 use js_sys::{Array, Object};
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::ops::Add;
+use std::{fmt, ops::Add};
 use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/game/visual.rs
+++ b/src/game/visual.rs
@@ -1,0 +1,493 @@
+use crate::{game::pathfinder::Position, traits::GameObjectProperties};
+use js_sys::Array;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VisualPosition {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl VisualPosition {
+    pub fn offset(&self, x: f32, y: f32) -> VisualPosition {
+        VisualPosition {
+            x: self.x + x,
+            y: self.y + y,
+        }
+    }
+}
+
+impl From<&Position> for VisualPosition {
+    fn from(pos: &Position) -> Self {
+        VisualPosition {
+            x: pos.x as f32,
+            y: pos.y as f32,
+        }
+    }
+}
+
+impl From<Position> for VisualPosition {
+    fn from(pos: Position) -> Self {
+        VisualPosition {
+            x: pos.x as f32,
+            y: pos.y as f32,
+        }
+    }
+}
+
+impl<T> From<T> for VisualPosition
+where
+    T: GameObjectProperties,
+{
+    fn from(obj: T) -> Self {
+        VisualPosition {
+            x: obj.x() as f32,
+            y: obj.y() as f32,
+        }
+    }
+}
+
+impl From<VisualPosition> for JsValue {
+    fn from(pos: VisualPosition) -> JsValue {
+        serde_wasm_bindgen::to_value(&pos).expect("serializable VisualPosition")
+    }
+}
+
+impl From<&VisualPosition> for JsValue {
+    fn from(pos: &VisualPosition) -> JsValue {
+        serde_wasm_bindgen::to_value(pos).expect("serializable VisualPosition")
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CircleStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    radius: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+}
+
+impl CircleStyle {
+    pub fn radius(mut self, val: f32) -> CircleStyle {
+        self.radius = Some(val);
+        self
+    }
+
+    pub fn fill(mut self, val: &str) -> CircleStyle {
+        self.fill = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> CircleStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> CircleStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> CircleStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+}
+
+impl From<CircleStyle> for JsValue {
+    fn from(style: CircleStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(&style).expect("serializable CircleStyle")
+    }
+}
+
+impl From<&CircleStyle> for JsValue {
+    fn from(circle: &CircleStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(circle).expect("serializable CircleStyle")
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LineDrawStyle {
+    #[default]
+    Solid,
+    Dashed,
+    Dotted,
+}
+
+impl LineDrawStyle {
+    pub fn is_solid(&self) -> bool {
+        matches!(self, LineDrawStyle::Solid)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LineStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "LineDrawStyle::is_solid")]
+    line_style: LineDrawStyle,
+}
+
+impl LineStyle {
+    pub fn width(mut self, val: f32) -> LineStyle {
+        self.width = Some(val);
+        self
+    }
+
+    pub fn color(mut self, val: &str) -> LineStyle {
+        self.color = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> LineStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn line_style(mut self, val: LineDrawStyle) -> LineStyle {
+        self.line_style = val;
+        self
+    }
+}
+
+impl From<LineStyle> for JsValue {
+    fn from(style: LineStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(&style).expect("serializable LineStyle")
+    }
+}
+
+impl From<&LineStyle> for JsValue {
+    fn from(style: &LineStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(style).expect("serializable LineStyle")
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RectStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "LineDrawStyle::is_solid")]
+    line_style: LineDrawStyle,
+}
+
+impl RectStyle {
+    pub fn fill(mut self, val: &str) -> RectStyle {
+        self.fill = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> RectStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> RectStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> RectStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+
+    pub fn line_style(mut self, val: LineDrawStyle) -> RectStyle {
+        self.line_style = val;
+        self
+    }
+}
+
+impl From<RectStyle> for JsValue {
+    fn from(style: RectStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(&style).expect("serializable RectStyle")
+    }
+}
+
+impl From<&RectStyle> for JsValue {
+    fn from(style: &RectStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(style).expect("serializable RectStyle")
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PolyStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "LineDrawStyle::is_solid")]
+    line_style: LineDrawStyle,
+}
+
+impl PolyStyle {
+    pub fn fill(mut self, val: &str) -> PolyStyle {
+        self.fill = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> PolyStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> PolyStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> PolyStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+
+    pub fn line_style(mut self, val: LineDrawStyle) -> PolyStyle {
+        self.line_style = val;
+        self
+    }
+}
+
+impl From<PolyStyle> for JsValue {
+    fn from(style: PolyStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(&style).expect("serializable PolyStyle")
+    }
+}
+
+impl From<&PolyStyle> for JsValue {
+    fn from(style: &PolyStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(style).expect("serializable PolyStyle")
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+enum FontStyle {
+    Size(f32),
+    Custom(String),
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TextAlign {
+    #[default]
+    Center,
+    Left,
+    Right,
+}
+
+impl TextAlign {
+    pub fn is_center(&self) -> bool {
+        matches!(self, TextAlign::Center)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font: Option<FontStyle>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background_padding: Option<f32>,
+    #[serde(skip_serializing_if = "TextAlign::is_center")]
+    align: TextAlign,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+}
+
+impl TextStyle {
+    pub fn color(mut self, val: &str) -> TextStyle {
+        self.color = Some(val.to_string());
+        self
+    }
+
+    pub fn font_size(mut self, val: f32) -> TextStyle {
+        self.font = Some(FontStyle::Size(val));
+        self
+    }
+
+    pub fn font_style(mut self, val: &str) -> TextStyle {
+        self.font = Some(FontStyle::Custom(val.to_string()));
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> TextStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> TextStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+
+    pub fn background_color(mut self, val: &str) -> TextStyle {
+        self.background_color = Some(val.to_string());
+        self
+    }
+
+    pub fn background_padding(mut self, val: f32) -> TextStyle {
+        self.background_padding = Some(val);
+        self
+    }
+
+    pub fn align(mut self, val: TextAlign) -> TextStyle {
+        self.align = val;
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> TextStyle {
+        self.opacity = Some(val);
+        self
+    }
+}
+
+impl From<TextStyle> for JsValue {
+    fn from(style: TextStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(&style).expect("serializable TextStyle")
+    }
+}
+
+impl From<&TextStyle> for JsValue {
+    fn from(style: &TextStyle) -> JsValue {
+        serde_wasm_bindgen::to_value(style).expect("serializable TextStyle")
+    }
+}
+
+#[wasm_bindgen(module = "game/visual")]
+extern "C" {
+    #[wasm_bindgen]
+    pub type Visual;
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(layer: Option<i32>, persistent: bool) -> Visual;
+
+    #[wasm_bindgen(method, getter)]
+    pub fn layer(this: &Visual) -> i32;
+
+    #[wasm_bindgen(method, getter)]
+    pub fn persistent(this: &Visual) -> bool;
+
+    #[wasm_bindgen(method, js_name = circle)]
+    pub fn circle_internal(this: &Visual, pos: &JsValue, style: &JsValue) -> Visual;
+
+    #[wasm_bindgen(method, js_name = line)]
+    pub fn line_internal(this: &Visual, from: &JsValue, to: &JsValue, style: &JsValue) -> Visual;
+
+    #[wasm_bindgen(method, js_name = rect)]
+    pub fn rect_internal(
+        this: &Visual,
+        top_left: &JsValue,
+        width: f32,
+        height: f32,
+        style: &JsValue,
+    ) -> Visual;
+
+    #[wasm_bindgen(method, js_name = poly)]
+    pub fn poly_internal(this: &Visual, points: &Array, style: &JsValue) -> Visual;
+
+    #[wasm_bindgen(method, js_name = text)]
+    pub fn text_internal(this: &Visual, text: &str, pos: &JsValue, style: &JsValue) -> Visual;
+}
+
+impl Visual {
+    pub fn circle(self: &Visual, pos: &VisualPosition, style: Option<&CircleStyle>) -> Visual {
+        match style {
+            Some(style) => self.circle_internal(&JsValue::from(pos), &JsValue::from(style)),
+            None => self.circle_internal(&JsValue::from(pos), &JsValue::UNDEFINED),
+        }
+    }
+
+    pub fn line(
+        self: &Visual,
+        from: &VisualPosition,
+        to: &VisualPosition,
+        style: Option<&LineStyle>,
+    ) -> Visual {
+        match style {
+            Some(style) => self.line_internal(
+                &JsValue::from(from),
+                &JsValue::from(to),
+                &JsValue::from(style),
+            ),
+            None => self.line_internal(
+                &JsValue::from(from),
+                &JsValue::from(to),
+                &JsValue::UNDEFINED,
+            ),
+        }
+    }
+
+    pub fn rect(
+        self: &Visual,
+        top_left: &VisualPosition,
+        width: f32,
+        height: f32,
+        style: Option<&RectStyle>,
+    ) -> Visual {
+        match style {
+            Some(style) => self.rect_internal(
+                &JsValue::from(top_left),
+                width,
+                height,
+                &JsValue::from(style),
+            ),
+            None => {
+                self.rect_internal(&JsValue::from(top_left), width, height, &JsValue::UNDEFINED)
+            }
+        }
+    }
+
+    pub fn poly(self: &Visual, points: &[VisualPosition], style: Option<&PolyStyle>) -> Visual {
+        let points = points.iter().cloned().map(JsValue::from).collect();
+        match style {
+            Some(style) => self.poly_internal(&points, &JsValue::from(style)),
+            None => self.poly_internal(&points, &JsValue::UNDEFINED),
+        }
+    }
+
+    pub fn text(
+        self: &Visual,
+        text: &str,
+        pos: &VisualPosition,
+        style: Option<&TextStyle>,
+    ) -> Visual {
+        match style {
+            Some(style) => self.text_internal(text, &JsValue::from(pos), &JsValue::from(style)),
+
+            None => self.text_internal(text, &JsValue::from(pos), &JsValue::UNDEFINED),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 // to build locally with doc_cfg enabled, run:
 // `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
 // temporary workaround for https://github.com/rust-lang/rust-clippy/issues/12377
 // fix not being in current stable rust 1.78; should be fixed in 1.79
 #![allow(clippy::empty_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 // `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+// temporary workaround for https://github.com/rust-lang/rust-clippy/issues/12377
+// fix not being in current stable rust 1.78; should be fixed in 1.79
+#![allow(clippy::empty_docs)]
+
 pub mod constants;
 pub mod enums;
 pub mod game;

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -104,6 +104,10 @@ extern "C" {
     #[wasm_bindgen(final, method, js_name = rangedMassAttack)]
     pub fn ranged_mass_attack(this: &Creep) -> ReturnCode;
 
+    /// This Creep attribute is only documented in the typescript typings.
+    #[wasm_bindgen(method, getter)]
+    pub fn spawning(this: &Creep) -> bool;
+
     // todo not yet in game but should be like this
     // #[wasm_bindgen(final, method)]
     // pub fn repair(this: &Creep, target: &GameObject) -> ReturnCode;

--- a/src/objects/impls/game_object.rs
+++ b/src/objects/impls/game_object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    game::pathfinder::{FindPathOptions, SearchResults},
+    game::pathfinder::{FindPathOptions, Position, SearchResults},
     prelude::*,
 };
 use js_sys::{Array, JsString, Object};
@@ -79,6 +79,13 @@ impl GameObject {
             }
         }
     }
+
+    pub fn pos(&self) -> Position {
+        Position {
+            x: self.x(),
+            y: self.y(),
+        }
+    }
 }
 
 impl<T> GameObjectProperties for T
@@ -99,6 +106,10 @@ where
 
     fn y(&self) -> u8 {
         GameObject::y(self.as_ref())
+    }
+
+    fn pos(&self) -> Position {
+        GameObject::pos(self.as_ref())
     }
 
     fn ticks_to_decay(&self) -> Option<u32> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@ use js_sys::{Array, JsString, Object};
 
 use crate::{
     enums::*,
-    game::pathfinder::{FindPathOptions, SearchResults},
+    game::pathfinder::{FindPathOptions, Position, SearchResults},
     objects::*,
 };
 
@@ -151,6 +151,8 @@ pub trait GameObjectProperties {
 
     /// The Y coordinate in the room.
     fn y(&self) -> u8;
+
+    fn pos(&self) -> Position;
 
     /// If defined, then this object will disappear after this number of ticks.
     fn ticks_to_decay(&self) -> Option<u32>;


### PR DESCRIPTION
There are two parts to this pull request.

### Visuals
Firstly we have an implementation of visuals for arena, which allows you to do horrific things like this.
![image](https://github.com/rustyscreeps/screeps-arena-game-api/assets/1202593/3133dda8-db0d-4853-b5e5-e1f69f585e99)
The visual objects and the means of styling them are largely the same in arena as world, so I've been able to bring over the style structs from the rust world api, such as TextStyle, PolyStyle and CircleStyle. However the underlying API is a bit different so we can't serialise the visuals on the rust side then send them over to javascript in a single call (as the rust world api does); instead we have to keep switching between rust and js as we build up the objects.

A challenge with the design of this interface has been how to handle the specification of positions of the visuals. They're typically described in the game documentation as `May be GameObject or any object containing x and y properties`. Duck typing is not available in the rust type system, so I've considered two ways to pass these parameters. 

- We could just accept &JsValue everywhere (for example `pub fn circle(this: &Visual, pos: &JsValue, style: &JsValue)` and rely on the caller to do a serde conversion from whatever struct they want. This is close to the javascript semantics, but it essentially eliminates type checking, and why would you be writing rust code if you didn't like your code to be type-checked?
- What I've done instead is to define `struct VisualPosition {x: f32, y:f32}` alongside helper traits to obtain a VisualPosition from a GameObject. This means the api method can be type-checked: `pub fn circle(self: &Visual, pos: &VisualPosition, style: Option<&CircleStyle>)`.

```
impl<T> From<T> for VisualPosition
where
    T: GameObjectProperties,
{
    fn from(obj: T) -> Self {
        VisualPosition {
            x: obj.x() as f32,
            y: obj.y() as f32,
        }
    }
}
```

This lets us do `VisualPosition::from(&creep)`. But sometimes we're not dealing with GameObjects - perhaps a desired future attack position, or perhaps we're interested in the path a creep will be taking. So I've also added VisualPosition::from() for Position. This leads onto part 2 of this change, which is an improved Position struct from pathfinder. I've added a pos() method to GameObjects, which returns a Position.

``` 
  Visual::new(None, false)
      .line(
        &VisualPosition::from(creep.pos()).offset(-1.5, -1.5),
        &VisualPosition::from(&creep).offset(1.5, 1.5),
        None,
      )
      .rect(&VisualPosition::from(creep.pos()), 1.0, 1.0, None);
```
### Position
The second part of this change lets us obtain pathfinder's Position struct from every GameObject via a pos() method, and the Position struct is augmented with PartialEq and Hash traits that allow use to do useful things with Position, and I've added a `From<Position> for JsValue` so that it can be easily converted into JsValue for bindgen api functions.

I've added Add<Direction> for Position trait, as well as checked_add_direction() and saturating_add_direction(), to keep commonality with the world api.

Note that Position contains u8 x/y coordinates that correspond to coordinates in the game world, while VisualPosition contains floating point x/y coordinates as visuals can be placed at fractional coordinate locations.

This Position work is partly here because it works nicely with the visual api methods, and partly because being able to use Position throughout your bot code is a useful alternative to x/y.

I don't think this Position work is too opinionated: Ranamar on discord has done some similar changes to his copy of the API so other people probably have too, adding pos() makes better use of an existing structure (rather than inventing something new), and it's a usage pattern familiar from world and the world API. So I don't think the Position commit is a big deal, but if it's seen as undesirable it could be separated from the Visual commit (I've kept the two commits largely independent).

### Demo Code

I've created a function to test the API, and it generated the visuals in the image above. I'll include it here as I think it's useful for showing how the new methods can be used.

```
fn test_visuals() {
  Visual::new(None, false).circle(
    &VisualPosition::from(Position { x: 25, y: 25 }),
    Some(&CircleStyle::default().radius(10.0).opacity(0.6)),
  );
  Visual::new(Some(2), false).circle(
    &VisualPosition::from(Position { x: 22, y: 25 }),
    Some(&CircleStyle::default().radius(5.0).opacity(1.0).fill("#00ff00")),
  );
  Visual::new(Some(-2), false).circle(
    &VisualPosition::from(Position { x: 19, y: 25 }),
    Some(&CircleStyle::default().radius(5.0).opacity(1.0).fill("#ff0000")),
  );

  let creep = game::utils::get_objects_by_prototype(prototypes::CREEP)
    .into_iter()
    .find(|c| c.my());
  if let Some(creep) = creep {
    Visual::new(None, false)
      .line(
        &VisualPosition::from(creep.pos()).offset(-1.5, -1.5),
        &VisualPosition::from(&creep).offset(1.5, 1.5),
        None,
      )
      .rect(&VisualPosition::from(creep.pos()), 1.0, 1.0, None);
  }

  Visual::new(None, false).poly(
    &vec![
      VisualPosition { x: 10.0, y: 10.0 },
      VisualPosition { x: 15.0, y: 10.0 },
      VisualPosition { x: 15.0, y: 15.0 },
      VisualPosition { x: 10.0, y: 10.0 },
    ],
    Some(&PolyStyle::default().stroke_width(0.7).line_style(LineDrawStyle::Dotted)),
  );

  Visual::new(None, false).text(
    "screeps",
    &VisualPosition { x: 0.0, y: 20.0 },
    Some(
      &TextStyle::default()
        .color("#0000FF")
        .font_style("bold italic 5.5 Times New Roman")
        .stroke("#00ff00")
        .stroke_width(0.4)
        .background_color("#ff0000")
        .opacity(0.6),
    ),
  );

  Visual::new(None, false).text(
    "arena",
    &VisualPosition { x: 5.0, y: 25.0 },
    Some(&TextStyle::default().color("#0000FF").font_size(5.5)),
  );

  let line_start = VisualPosition { x: 0.0, y: 22.5 };
  Visual::new(None, false)
    .line(&line_start, &line_start.offset(15.0, 0.0), Some(&LineStyle::default()))
    .rect(
      &VisualPosition { x: -1.0, y: 18.0 },
      6.0,
      9.0,
      Some(&RectStyle::default().opacity(0.2).fill("#00ffff")),
    );
}
```

edit: updated to remove the stuff about AsRef, that wasn't needed for VisualPosition::from() of GameObject derived types.