### PR TITLE
feat: new constant SPAWN_RANGE

### DIFF
--- a/src/constants/numbers.rs
+++ b/src/constants/numbers.rs
@@ -96,3 +96,5 @@ pub const EXTENSION_ENERGY_CAPACITY: u32 = 100;
 pub const SPAWN_ENERGY_CAPACITY: u32 = 1000;
 
 pub const SPAWN_HITS: u32 = 3000;
+
+pub const SPAWN_RANGE: u32 = 20;


### PR DESCRIPTION
Season 3 introduces the SPAWN_RANGE constant (defining the range at which energy can be consumed from a spawn or extension to spawn a creep).

https://arena.screeps.com/docs#Constants